### PR TITLE
fix: disable single-key hotkeys inside input fields

### DIFF
--- a/hooks/use-haptic-toggle.ts
+++ b/hooks/use-haptic-toggle.ts
@@ -39,8 +39,6 @@ export const useHapticsToggle = () => {
     "h",
     () => toggleHaptics(),
     {
-      enableOnContentEditable: false,
-      enableOnFormTags: false,
       preventDefault: true,
     },
     [toggleHaptics]

--- a/hooks/use-haptic-toggle.ts
+++ b/hooks/use-haptic-toggle.ts
@@ -39,8 +39,8 @@ export const useHapticsToggle = () => {
     "h",
     () => toggleHaptics(),
     {
-      enableOnContentEditable: true,
-      enableOnFormTags: true,
+      enableOnContentEditable: false,
+      enableOnFormTags: false,
       preventDefault: true,
     },
     [toggleHaptics]

--- a/hooks/use-sound-toggle.ts
+++ b/hooks/use-sound-toggle.ts
@@ -29,8 +29,8 @@ export const useSoundToggle = () => {
     "s",
     () => toggleSound(),
     {
-      enableOnContentEditable: true,
-      enableOnFormTags: true,
+      enableOnContentEditable: false,
+      enableOnFormTags: false,
       preventDefault: true,
     },
     [toggleSound]

--- a/hooks/use-sound-toggle.ts
+++ b/hooks/use-sound-toggle.ts
@@ -29,8 +29,6 @@ export const useSoundToggle = () => {
     "s",
     () => toggleSound(),
     {
-      enableOnContentEditable: false,
-      enableOnFormTags: false,
       preventDefault: true,
     },
     [toggleSound]

--- a/hooks/use-theme-toggle.ts
+++ b/hooks/use-theme-toggle.ts
@@ -33,8 +33,8 @@ export const useThemeToggle = () => {
     "d",
     () => toggleTheme(),
     {
-      enableOnContentEditable: true,
-      enableOnFormTags: true,
+      enableOnContentEditable: false,
+      enableOnFormTags: false,
       preventDefault: true,
     },
     [toggleTheme]

--- a/hooks/use-theme-toggle.ts
+++ b/hooks/use-theme-toggle.ts
@@ -33,8 +33,6 @@ export const useThemeToggle = () => {
     "d",
     () => toggleTheme(),
     {
-      enableOnContentEditable: false,
-      enableOnFormTags: false,
       preventDefault: true,
     },
     [toggleTheme]


### PR DESCRIPTION
### Summary

Single-key hotkeys (`d`, `s`, `h`) for toggling theme, sound, and haptics were firing inside input fields and contenteditable elements. This caused typing `d` in the theme builder export name field (or any other text input) to toggle the theme instead of inserting the character.

Removed `enableOnContentEditable` and `enableOnFormTags` options from all three `useHotkeys` calls, letting them default to `false` so shortcuts only fire when focus is on the page body.

### Validation

- Ran `pnpm typecheck` — passed
- Ran `pnpm check` — passed (0 warnings, 0 errors)
- Verified typing `d`, `s`, `h` in text inputs no longer triggers shortcuts

Screen Recordings:
Before -

https://github.com/user-attachments/assets/80684937-9f9d-4587-8d66-1cf2beba8e8d

After -

https://github.com/user-attachments/assets/6813147b-ae2a-44a8-8878-ba9ed36ccd6b

### Checklist

- [x] I ran the relevant checks from [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `pnpm check` and `pnpm typecheck` successfully
