### PR TITLE
fix: use valid Text variant in installation docs

### DIFF
--- a/content/docs/(root)/installation.mdx
+++ b/content/docs/(root)/installation.mdx
@@ -37,7 +37,7 @@ export function Invoice() {
     <Document>
       <Page size="A4">
         <PdfcnThemeProvider>
-          <Text variant="title">Invoice</Text>
+          <Text variant="xl">Invoice</Text>
         </PdfcnThemeProvider>
       </Page>
     </Document>


### PR DESCRIPTION
Fixes #5

The installation page Usage example uses `<Text variant="title">Invoice</Text>`, but the `Text` component only accepts `xs | sm | base | lg | xl | 2xl | 3xl` as variants.

Changes `variant="title"` to `variant="xl"` — an appropriate size for an invoice heading.